### PR TITLE
Store peptide IDs as strings.

### DIFF
--- a/src/js/modules/AjaxDataProvider.js
+++ b/src/js/modules/AjaxDataProvider.js
@@ -296,7 +296,7 @@ function AjaxDataProvider(confObj) { // eslint-disable-line no-unused-vars
                 var obj = {};
                 cv.forEach(function (d, idx) {
                     var escapedField = '"' + cNames[idx] + '"';
-                    if (isNumber(d))
+                    if (isNumber(d) && cNames[idx] != 'PEPTIDE_ID')
                     {
                         obj[escapedField] = Number.parseFloat(d);
                     } else {


### PR DESCRIPTION
Stores peptide ID from query as a string. This resolves a bug where the IDs were greater than MAX_SAFE_INTEGER, and rounded down.